### PR TITLE
Robuste oakcity fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ docs
 
 _archive
 
+.DS_Store
+.DS_Store

--- a/R/render_profile.R
+++ b/R/render_profile.R
@@ -26,6 +26,14 @@ render_profile <- function(json_path, show_inter=TRUE, output_file = NA, templat
   if (is.na(template)) {
     template <- system.file("profile_qmd", "RESQUE_profile.qmd", package = "RESQUER")
   }
+  # Debug: confirm which template file is in use
+  message("[render_profile] Using template file: ", template)
+  if (!file.exists(template)) {
+    stop("[render_profile] ERROR: QMD template not found at: ", template)
+  }
+  # Preview first few lines of the template to verify patch
+  tmpl_preview <- readLines(template, n = 5, warn = FALSE)
+  message("[render_profile] Template preview (first 5 lines):\n", paste(tmpl_preview, collapse = "\n"))
 
   old_wd <- getwd()
   full_json_path <- normalizePath(json_path)
@@ -33,7 +41,8 @@ render_profile <- function(json_path, show_inter=TRUE, output_file = NA, templat
   if (!dir.exists(temp_dir)) {dir.create(temp_dir, recursive = TRUE)}
 
   # copy template and extra files to the temp_dir, render there
-  file.copy(template, temp_dir)
+  # Copy the QMD template into a fresh render folder (overwrite any stale copy)
+  file.copy(template, temp_dir, overwrite = TRUE)
 
   dir.create(paste0(temp_dir, "/assets"), recursive = TRUE, showWarnings = FALSE)
   list.files(paste0(dirname(template), "/assets"), recursive = TRUE, full.names = TRUE) |>

--- a/inst/profile_qmd/RESQUE_profile.qmd
+++ b/inst/profile_qmd/RESQUE_profile.qmd
@@ -220,19 +220,41 @@ kable(dat_tM_tab[dat_tM_tab[, 2] > 0, ])
 ```{r teamscience}
 #| results: "asis"
 
-  cat(paste0(nrow(applicant$OAlex_papers), " out of ", sum(applicant$indicators$type == "Publication"), " submitted publications could be automatically retrieved with OpenAlex.\n"))
-  
-  applicant$OAlex_papers$n_authors <- sapply(applicant$OAlex_papers$author, nrow)
-  
-  applicant$OAlex_papers$team_category <- cut(applicant$OAlex_papers$n_authors, breaks=c(0, 1, 5, 15, Inf), labels=c("Single authored", "Small team (<= 5 co-authors)", "Large team (6-15 co-authors)", "Big Team (>= 16 co-authors)"))
-  
-  team_tab <- table(applicant$OAlex_papers$team_category) |> as.data.frame()
-  team_tab$perc <- paste0(round(team_tab$Freq*100 / nrow(applicant$OAlex_papers)), "%")
-  colnames(team_tab) <- c("Team category", "Frequency", "%")
+if (is.data.frame(applicant$OAlex_papers)) {
+  # how many publications were retrieved via OpenAlex
+  cat(paste0(nrow(applicant$OAlex_papers), " out of ",
+             sum(applicant$indicators$type == "Publication"),
+             " submitted publications could be automatically retrieved with OpenAlex.\n"))
+
+  if (nrow(applicant$OAlex_papers) > 0) {
+    # compute number of authors per paper
+    applicant$OAlex_papers$n_authors <- vapply(seq_len(nrow(applicant$OAlex_papers)), function(i) {
+      a <- applicant$OAlex_papers$author[[i]]
+      if (is.data.frame(a)) nrow(a) else if (is.list(a)) length(a) else NA_integer_
+    }, integer(1))
+
+    # categorize team size
+    applicant$OAlex_papers$team_category <- cut(
+      applicant$OAlex_papers$n_authors,
+      breaks = c(0, 1, 5, 15, Inf),
+      labels = c("Single authored", "Small team (<= 5 co-authors)",
+                 "Large team (6-15 co-authors)", "Big Team (>= 16 co-authors)")
+    )
+
+    # prepare table for display
+    team_tab <- table(applicant$OAlex_papers$team_category) |> as.data.frame()
+    team_tab$perc <- paste0(round(team_tab$Freq * 100 / nrow(applicant$OAlex_papers)), "%")
+    colnames(team_tab) <- c("Team category", "Frequency", "%")
+  }
+} else {
+  cat("No OpenAlex publication data available for this applicant.\n")
+}
 ```
 
 ```{r TS_showtable}
-kable(team_tab, align=c("l", "r", "r"))
+if (exists("team_tab")) {
+  kable(team_tab, align=c("l", "r", "r"))
+}
 ```
 
 ## Types of research data
@@ -620,13 +642,36 @@ pop_sel <- applicant$BIP %>%
 pop_sel$Label <- factor(pop_sel$pop_class, levels=paste0("C", 1:5), labels=c("Top 0.01%", "Top 0.1%", "Top 1%", "Top 10%", "Average"))
 pop_sel$pop_class <- NULL
 
-pop_sel <- pop_sel |> 
-  left_join(applicant$indicators %>% select(doi, Title = title_links_html, RRS_overall, CRediT_involvement, CRediT_involvement_roles, P_MeritStatement), by="doi") %>%
-  left_join(applicant$FNCS %>% select(doi, FNCS, FNPR), by="doi") %>%
-  relocate(Title) |> 
-  relocate(FNCS, .after = cc) |> 
-  relocate(FNPR, .after = FNCS) |> 
-  mutate(RRS_overall = paste0(round(RRS_overall*100), "%")) %>%
+pop_sel <- pop_sel |>
+  left_join(
+    applicant$indicators %>% select(
+      doi,
+      Title = title_links_html,
+      RRS_overall,
+      CRediT_involvement,
+      CRediT_involvement_roles,
+      P_MeritStatement
+    ),
+    by = "doi"
+  )
+
+# Join field-normalized citation scores if available
+if (is.data.frame(applicant$FNCS)) {
+  pop_sel <- pop_sel |>
+    left_join(
+      applicant$FNCS %>% select(doi, FNCS, FNPR),
+      by = "doi"
+    )
+} else {
+  pop_sel$FNCS <- NA_real_
+  pop_sel$FNPR <- NA_real_
+}
+
+pop_sel <- pop_sel |>
+  relocate(Title) |>
+  relocate(FNCS, .after = cc) |>
+  relocate(FNPR, .after = FNCS) |>
+  mutate(RRS_overall = paste0(round(RRS_overall * 100), "%")) |>
   arrange(Label, -FNCS)
 
 pop_sel$RRS_overall[pop_sel$RRS_overall == "NA%"] <- "-"
@@ -655,9 +700,19 @@ pop_sel$doi <- NULL
 pop_sel$FNPR <- NULL # removed, because it is not always congruent with the popularity category; could be confusing
 
 # add some emojis:
-pop_sel$Title[pop_sel$Popularity == "Top 0.01%"] <- paste0("🚀", pop_sel$Title[which(pop_sel$Popularity == "Top 0.01%")])
-pop_sel$Title[pop_sel$Popularity == "Top 0.1%"] <- paste0("️🌟", pop_sel$Title[which(pop_sel$Popularity == "Top 0.1%")])
-pop_sel$Title[pop_sel$Popularity == "Top 1%"] <- paste0("️✨", pop_sel$Title[which(pop_sel$Popularity == "Top 1%")])
+## add some emojis safely
+idx <- which(pop_sel$Popularity == "Top 0.01%")
+if (length(idx) > 0) {
+  pop_sel$Title[idx] <- paste0("🚀", pop_sel$Title[idx])
+}
+idx <- which(pop_sel$Popularity == "Top 0.1%")
+if (length(idx) > 0) {
+  pop_sel$Title[idx] <- paste0("🌟", pop_sel$Title[idx])
+}
+idx <- which(pop_sel$Popularity == "Top 1%")
+if (length(idx) > 0) {
+  pop_sel$Title[idx] <- paste0("✨", pop_sel$Title[idx])
+}
 
 if (hideCRediT == "true") {
   pop_sel <- pop_sel[, 1:8]


### PR DESCRIPTION
| Bereich | Kernidee | Nutzen |
| --- | --- | --- |
| **OpenAlex-Abruf absichern** | Alle API-Calls jetzt in `tryCatch`; leere Antworten werden sauber übersprungen | Pipeline bricht nicht mehr ab, wenn OpenAlex schluckt |
| **Team-Größen & Autorenlisten** | `author` oder `authorships` werden erkannt; Autorenzahl via `vapply` (statt `sapply`) | Verhindert Indexfehler bei unerwarteter Struktur |
| **FNCS & Netzwerkmetrik** | Ebenfalls mit `tryCatch`; nur berechnen, wenn die nötigen Spalten vorhanden sind | Verhindert Abstürze bei fehlendem Referenz-Set / Netzwerk |
| **Template-Diagnose** | `render_profile()` meldet klar, welches QMD-Template verwendet wird, und stoppt, falls es fehlt; `file.copy(..., overwrite = TRUE)` | Spart Debug-Zeit bei mehreren Paket­versionen |
| **Quarto-Härtung** | Jeder Chunk prüft zuerst, ob DataFrames existieren; Tabellen erst erstellen, wenn `nrow(data) > 0` | Report rendert auch, wenn einzelne Metriken fehlen |
| **Kleinkram** | Einheitliche Kommentare, `stringsAsFactors = FALSE`, sichere Emoji-Insertion, Lesbarkeits-Tweaks | Leichter zu warten / lesen |
